### PR TITLE
Improve docs linking to make it local testable

### DIFF
--- a/docs/event_handlers.md
+++ b/docs/event_handlers.md
@@ -1,5 +1,5 @@
 # Registering event handlers in reffects
 
-To register event handlers you need to use [reffects' `registerEventHandler`](https://github.com/trovit/reffects/blob/master/docs/api.md#registereventhandler)function. This function associates an event with its handler, so that, every time the event is dispatched, its event handler is executed.
+To register event handlers you need to use [reffects' `registerEventHandler`](/docs/api.md#registereventhandler)function. This function associates an event with its handler, so that, every time the event is dispatched, its event handler is executed.
 
-When you using [reffects' `registerEventHandler`](https://github.com/trovit/reffects/blob/master/docs/api.md#registereventhandler), you can use its third parameter, which is optional, to declare the coeffects that describe the values that the handler will need. Have a look at the [documentation of reffects' `registerEventHandler`](https://github.com/trovit/reffects/blob/master/docs/api.md#registereventhandler) to see more details and examples of usage.
+When you using [reffects' `registerEventHandler`](/docs/api.md#registereventhandler), you can use its third parameter, which is optional, to declare the coeffects that describe the values that the handler will need. Have a look at the [documentation of reffects' `registerEventHandler`](/docs/api.md#registereventhandler) to see more details and examples of usage.

--- a/docs/event_handlers.md
+++ b/docs/event_handlers.md
@@ -1,5 +1,5 @@
 # Registering event handlers in reffects
 
-To register event handlers you need to use [reffects' `registerEventHandler`](/docs/api.md#registereventhandler)function. This function associates an event with its handler, so that, every time the event is dispatched, its event handler is executed.
+To register event handlers you need to use reffects [`registerEventHandler`](/docs/api.md#registereventhandler)function. This function associates an event with its handler, so that, every time the event is dispatched, its event handler is executed.
 
-When you using [reffects' `registerEventHandler`](/docs/api.md#registereventhandler), you can use its third parameter, which is optional, to declare the coeffects that describe the values that the handler will need. Have a look at the [documentation of reffects' `registerEventHandler`](/docs/api.md#registereventhandler) to see more details and examples of usage.
+When you using reffects [`registerEventHandler`](/docs/api.md#registereventhandler), you can use its third parameter, which is optional, to declare the coeffects that describe the values that the handler will need. Have a look at the documentation of reffects [`registerEventHandler`](/docs/api.md#registereventhandler) to see more details and examples of usage.

--- a/docs/events_and_event_handlers.md
+++ b/docs/events_and_event_handlers.md
@@ -1,10 +1,10 @@
 # Events and event handlers
 
-reffects is a synchronous event bus with [effects and coeffects](https://github.com/trovit/reffects/blob/master/docs/effects_and_coeffects.md).
+reffects is a synchronous event bus with [effects and coeffects](/docs/effects_and_coeffects.md).
 
 Any application using reffects has a an [event-driven architecture](https://en.wikipedia.org/wiki/Event-driven_architecture).
 
-Thanks to the [declarative effects pattern](https://github.com/trovit/reffects/blob/master/docs/effects_and_coeffects.md#declarative-effects-pattern), all the event handlers in an application using reffects can be pure function.
+Thanks to the [declarative effects pattern](/docs/effects_and_coeffects.md#declarative-effects-pattern), all the event handlers in an application using reffects can be pure function.
 
 Pure functions offer great advantages over effectful functions because they are
 
@@ -22,6 +22,6 @@ In an application using reffects, you should write all your state management log
 
 More on event handlers:
 
-1. [Registering event handlers](https://github.com/trovit/reffects/blob/master/docs/event_handlers.md).
+1. [Registering event handlers](/docs/event_handlers.md).
 
-2. [Testing event handlers](https://github.com/trovit/reffects/blob/master/docs/testing_event_handlers.md).
+2. [Testing event handlers](/docs/testing_event_handlers.md).

--- a/examples/with-react-todos/docs/custom_coeffects.md
+++ b/examples/with-react-todos/docs/custom_coeffects.md
@@ -25,7 +25,7 @@ registerEventHandler(
     [coeffect("datetime")]
 );
 ```
-Here we used the third parameter of [reffects' registerEventHandler](/docs/api.md#registereventhandler) function to declare the list of coeffects that the event handler of the `displayTime` event will receive when called. In this case, it includes only the `datetime` coeffect.
+Here we used the third parameter of reffect [registerEventHandler](/docs/api.md#registereventhandler) function to declare the list of coeffects that the event handler of the `displayTime` event will receive when called. In this case, it includes only the `datetime` coeffect.
 
 Notice how the value associated to the `datetime` coeffect, which is a timestamp, comes in the **coeffects object** (which is the first parameter of any event handler in reffects).
 
@@ -55,7 +55,7 @@ registerEventHandler(
   },
   [coeffect('state.get', {todos: 'todos'})]);
 ```
-In this example we used the third parameter of [reffects' registerEventHandler](/docs/api.md#registereventhandler) function to declare the list of coeffects that the event handler of the `todoClicked` event will receive when called. In this case, it includes only the `state` coeffect. To declare it we're using the `coeffect` function which is a coeffects factory function, in `coeffect('state.get', {todos: 'todos'})`. This factory function receives an object whose entries (key-value pairs) represent *extractions*. Each extraction (key-value pair) is interpreted as:
+In this example we used the third parameter of reffects [registerEventHandler](/docs/api.md#registereventhandler) function to declare the list of coeffects that the event handler of the `todoClicked` event will receive when called. In this case, it includes only the `state` coeffect. To declare it we're using the `coeffect` function which is a coeffects factory function, in `coeffect('state.get', {todos: 'todos'})`. This factory function receives an object whose entries (key-value pairs) represent *extractions*. Each extraction (key-value pair) is interpreted as:
 
 1. The key represents the **key** that the value will be associated to in the object associated to the `state` key in the coeffects object.
 
@@ -100,6 +100,6 @@ registerEventHandler(
     [coeffect("apiUrl")]
 );
 ```
-Here we used the third parameter of [reffects' registerEventHandler](/docs/api.md#registereventhandler) function to declare the list of coeffects that the event handler of the `loadTodos` event will receive when called. In this case, it includes only the `apiUrl` coeffect.
+Here we used the third parameter of reffects [registerEventHandler](/docs/api.md#registereventhandler) function to declare the list of coeffects that the event handler of the `loadTodos` event will receive when called. In this case, it includes only the `apiUrl` coeffect.
 
 Notice how the value associated to the `apiUrl` coeffect, which is a string, comes in the **coeffects object** (which is the first parameter of any event handler in reffects).

--- a/examples/with-react-todos/docs/custom_coeffects.md
+++ b/examples/with-react-todos/docs/custom_coeffects.md
@@ -25,7 +25,7 @@ registerEventHandler(
     [coeffect("datetime")]
 );
 ```
-Here we used the third parameter of [reffects' registerEventHandler](https://github.com/trovit/reffects/blob/master/docs/api.md#registereventhandler) function to declare the list of coeffects that the event handler of the `displayTime` event will receive when called. In this case, it includes only the `datetime` coeffect.
+Here we used the third parameter of [reffects' registerEventHandler](/docs/api.md#registereventhandler) function to declare the list of coeffects that the event handler of the `displayTime` event will receive when called. In this case, it includes only the `datetime` coeffect.
 
 Notice how the value associated to the `datetime` coeffect, which is a timestamp, comes in the **coeffects object** (which is the first parameter of any event handler in reffects).
 
@@ -55,7 +55,7 @@ registerEventHandler(
   },
   [coeffect('state.get', {todos: 'todos'})]);
 ```
-In this example we used the third parameter of [reffects' registerEventHandler](https://github.com/trovit/reffects/blob/master/docs/api.md#registereventhandler) function to declare the list of coeffects that the event handler of the `todoClicked` event will receive when called. In this case, it includes only the `state` coeffect. To declare it we're using the `coeffect` function which is a coeffects factory function, in `coeffect('state.get', {todos: 'todos'})`. This factory function receives an object whose entries (key-value pairs) represent *extractions*. Each extraction (key-value pair) is interpreted as:
+In this example we used the third parameter of [reffects' registerEventHandler](/docs/api.md#registereventhandler) function to declare the list of coeffects that the event handler of the `todoClicked` event will receive when called. In this case, it includes only the `state` coeffect. To declare it we're using the `coeffect` function which is a coeffects factory function, in `coeffect('state.get', {todos: 'todos'})`. This factory function receives an object whose entries (key-value pairs) represent *extractions*. Each extraction (key-value pair) is interpreted as:
 
 1. The key represents the **key** that the value will be associated to in the object associated to the `state` key in the coeffects object.
 
@@ -100,6 +100,6 @@ registerEventHandler(
     [coeffect("apiUrl")]
 );
 ```
-Here we used the third parameter of [reffects' registerEventHandler](https://github.com/trovit/reffects/blob/master/docs/api.md#registereventhandler) function to declare the list of coeffects that the event handler of the `loadTodos` event will receive when called. In this case, it includes only the `apiUrl` coeffect.
+Here we used the third parameter of [reffects' registerEventHandler](/docs/api.md#registereventhandler) function to declare the list of coeffects that the event handler of the `loadTodos` event will receive when called. In this case, it includes only the `apiUrl` coeffect.
 
 Notice how the value associated to the `apiUrl` coeffect, which is a string, comes in the **coeffects object** (which is the first parameter of any event handler in reffects).

--- a/packages/reffects-store/README.md
+++ b/packages/reffects-store/README.md
@@ -6,5 +6,5 @@ This library is an implementation of a store for React including the subscriptio
 
 ## Documentation
 
-- [Store](../../docs/reffects_store/store_api.md)
-- [Subscriptions](../../docs/reffects_store/subscriptions_api.md)
+- [Store](/docs/reffects_store/store_api.md)
+- [Subscriptions](/docs/reffects_store/subscriptions_api.md)


### PR DESCRIPTION
### Fix minor mistype

In `event_handlers.md` and `.../with-react-todos/.../custom_coeffects.md` I find a mistype which includes to link previous words instead of only the name of the function.

> [reffects' registerEventHandler](/docs/api.md#registereventhandler) function

instead

> reffects [registerEventHandler](/docs/api.md#registereventhandler) function


### Change linking to avoid use full url

When trying to fix the mistype mentioned before I found that docs are using a full url making my changes untestable. I removed all references to urls and change it for internals project links.

> https://github.com/trovit/reffects/blob/master/docs/api.md#registereventhandler

for 

> /docs/api.md#registereventhandler
