### PR TITLE
📑️ Add type declarations in order to enable better IDE integration an…

### DIFF
--- a/packages/reffects/index.d.ts
+++ b/packages/reffects/index.d.ts
@@ -1,0 +1,35 @@
+// Type definitions for reffects
+// Project: reffects
+// Definitions by: Gabriele Lippi - https://www.github.com/glippi
+interface Event {
+    id: string;
+    payload?: object;
+}
+
+interface Effect {
+    id: string;
+    data: object;
+}
+
+interface Coeffect{
+    id: string;
+    data?: object;
+}
+
+type EventHandler = (coeffect?: Coeffect, payload?: object) => Effect;
+
+type EffectHandler = Function;
+
+type CoeffectHandler = Function;
+
+export function dispatch(event: Event): void;
+export function dispatchMany(events: Event[]): void;
+export function dispatchLater(event: Event): void;
+export function registerEventHandler(eventId: string, handler: EventHandler, coeffectDescriptions?: string[]): void;
+export function registerCoeffectHandler(coeffectId: string, handler: CoeffectHandler): void;
+export function registerEffectHandler(effectId: string, handler: EffectHandler): void;
+export function registerEventsDelegation(originalEvents: string[], targetEvent: string): void;
+export function coeffect(id: string, data?: object): Coeffect;
+export function getEffectHandler(effectId: string): EffectHandler; 
+export function getCoeffectHandler(coeffectId: string): CoeffectHandler;
+export function getEventHandler(eventId: string): EventHandler;

--- a/packages/reffects/package.json
+++ b/packages/reffects/package.json
@@ -7,6 +7,7 @@
   "main": "dist/reffects.js",
   "umd:main": "dist/reffects.umd.js",
   "keywords": [],
+  "types": "index.d.ts",
   "devDependencies": {
     "@babel/core": "^7.4.3",
     "@babel/preset-env": "^7.4.3",


### PR DESCRIPTION
…d autocompletion

### Summary

With this PR, I would suggest to add a `index.d.ts` file, containing type declarations for the methods that are exposed from reffects.
This should give a better developer experience to the user, as with the provided declarations, IDEs and text editors are able to suggest the interface of the method that one is using while is writing the code.

I'm not totally sure that all the methods are correctly defined, in that case I hope that we can improve the typings together ;)
