### PR TITLE
🐛️ Fix wrong function name in documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -140,7 +140,7 @@ Example:
 const loadTodosHandler = getEventHandler("loadTodos");
 ```
 
-## `getEventHandler`
+## `clearHandlers`
 This function is used only in tests fixtures and clears all the handlers of any type previously registered in `reffects`.
 
 Example:


### PR DESCRIPTION
### Summary

In the api docs,  `getEventHandler` is listed two times, where the second should reference `clearHandlers`.
