### PR TITLE
adding check of coeffects validity when calling event handlers direct…

### DIFF
--- a/packages/reffects/src/index.js
+++ b/packages/reffects/src/index.js
@@ -142,7 +142,7 @@ function createCoeffectsSpec(coeffectsDescriptions) {
     }
   ).reduce(
     function(acc, coeffectId) {
-      acc[coeffectId] = specsByHandler["coeffects"][coeffectId] || s.ANY;
+      acc[coeffectId] = getCoeffectSpec(coeffectId);
       return acc;
     },
     {}
@@ -171,11 +171,13 @@ function registerEventHandler(eventId, handler, coeffectDescriptions = []) {
   coeffectsByEvent[eventId] = coeffectDescriptions;
 }
 
-function registerCoeffectHandler(coeffectId, handler) {
+function registerCoeffectHandler(coeffectId, handler, spec = s.ANY) {
+  registerCoeffectSpec(coeffectId, spec)
   setHandler('coeffects', coeffectId, handler);
 }
 
-function registerEffectHandler(effectId, handler) {
+function registerEffectHandler(effectId, handler, spec = s.ANY) {
+  registerEffectSpec(effectId, spec)
   setHandler('effects', effectId, handler);
 }
 
@@ -234,6 +236,14 @@ function getCoeffectHandler(coeffectId) {
 
 function getEffectHandler(effectId) {
   return getHandler('effects', effectId);
+}
+
+function getCoeffectSpec(coeffectId) {
+  return specsByHandler["coeffects"][coeffectId];
+}
+
+function getEffectSpec(effectId) {
+  return specsByHandler["effects"][effectId];
 }
 
 function getEventHandler(eventId) {
@@ -307,8 +317,6 @@ export {
   registerCoeffectHandler,
   registerEffectHandler,
   registerEventsDelegation,
-  registerCoeffectSpec,
-  registerEffectSpec,
   coeffect,
   getEffectHandler,
   getCoeffectHandler,

--- a/packages/reffects/src/index.test.js
+++ b/packages/reffects/src/index.test.js
@@ -380,6 +380,7 @@ test('an exception is thrown, when the coeffect received is missing a required c
   const passedPayload = 'somePayload';
   const eventId = 'eventHandlerInWhichCoeffectsValuesAreInjected';
   const dummyEventHandler = () => {};
+  reffects.registerCoeffectHandler("moko", () => {});
   reffects.registerEventHandler(
     eventId,
     dummyEventHandler,
@@ -399,7 +400,7 @@ test('an exception is thrown, when the value any of the received does not confor
   const passedPayload = 'somePayload';
   const eventId = 'eventHandlerInWhichCoeffectsValuesAreInjected';
   const dummyEventHandler = () => {};
-  reffects.registerCoeffectSpec("moko", mokoCoeffectSpec);
+  reffects.registerCoeffectHandler("moko", () => {}, mokoCoeffectSpec);
 
   reffects.registerEventHandler(
     eventId,

--- a/packages/reffects/src/index.test.js
+++ b/packages/reffects/src/index.test.js
@@ -390,7 +390,7 @@ test('an exception is thrown, when the coeffect received is missing a required c
 
   expect(() =>
     eventHandler({"mioko": {}}, passedPayload)
-  ).toThrowError("{\"mioko\":{}} missing keywords (moko)");
+  ).toThrowError();
 });
 
 test('an exception is thrown, when the value any of the received does not conform to its spec', () => {
@@ -411,5 +411,5 @@ test('an exception is thrown, when the value any of the received does not confor
 
   expect(() =>
     eventHandler({"moko": {a: 1}}, passedPayload)
-  ).toThrowError(/key a with value 1 failures -> 1 fails spec.STRING/);
+  ).toThrowError();
 });


### PR DESCRIPTION
This change adds checking of coeffects validity when calling an event handlers directly in test and dev environments.

Now passing an invalid coeffects object to an event handler in a test will throw an exception. This will avoid that weak spot we had when testing event handlers.

By default, it checks only the presence as keys of the required coeffect ids in the coeffects object. 
However, if you register a spec (created with speco) for the coeffect's data it will also check that the corresponding value conforms with the spec.
