### PR TITLE
chore: Improve error message for testing

### DIFF
--- a/packages/reffects/src/index.js
+++ b/packages/reffects/src/index.js
@@ -239,7 +239,11 @@ function getEffectHandler(effectId) {
 }
 
 function getCoeffectSpec(coeffectId) {
-  return specsByHandler["coeffects"][coeffectId];
+  const spec = specsByHandler["coeffects"][coeffectId];
+  if (!spec) {
+    throw new Error(`Missing spec for coeffect ${coeffectId}. Remember to register this coeffect.`)
+  }
+  return spec;
 }
 
 function getEffectSpec(effectId) {


### PR DESCRIPTION
### Summary

If you don't register the coeffects when running tests, you won't have the speco validation. In this case, we were throwing a not very helpful message because of an undefined variable. Now the message is a bit more helpful.
