### PR TITLE
Modify badge for CI status to check github actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
   <a href="https://img.shields.io/npm/v/reffects">
     <img src="https://badgen.net/npm/v/reffects">
   </a> 
-  <a href="https://travis-ci.com/trovit/reffects">
-    <img src="https://travis-ci.com/trovit/reffects.svg?branch=master">
+  <a href="https://github.com/trovit/reffects/actions">
+    <img src="https://github.com/trovit/reffects/workflows/CI/badge.svg?branch=master">
   </a> 
   <a href="https://coveralls.io/github/trovit/reffects?branch=master">
     <img src="https://coveralls.io/repos/github/trovit/reffects/badge.svg?branch=master">


### PR DESCRIPTION
### Summary

In the README we have a badge showing the status of the CI in Travis. Since now we are using Github Actions, I updated the badge to check the Github Action status.
