### PR TITLE
Fix bug global

### DIFF
--- a/packages/batteries/src/global/global.js
+++ b/packages/batteries/src/global/global.js
@@ -1,5 +1,7 @@
 import { coeffect, registerCoeffectHandler } from 'reffects';
 
+const COEFFECT_ID = 'globals';
+
 function getPathArray(path) {
   return Array.isArray(path) ? path : path.split('.');
 }
@@ -15,13 +17,13 @@ function getIn(obj, path, defaultValue = null) {
 }
 
 export function globalsGet(path) {
-  return coeffect('globals', path);
+  return coeffect(COEFFECT_ID, path);
 }
 
 export default function registeGlobalCoeffect(globalObject = window) {
-  registerCoeffectHandler('globals', function global(variableName) {
+  registerCoeffectHandler(COEFFECT_ID, function global(variableName) {
     return {
-      globals: {
+      [COEFFECT_ID]: {
         [variableName]: getIn(globalObject, variableName),
       },
     };

--- a/packages/batteries/src/global/global.js
+++ b/packages/batteries/src/global/global.js
@@ -21,7 +21,7 @@ export function globalsGet(path) {
 export default function registeGlobalCoeffect(globalObject = window) {
   registerCoeffectHandler('globals', function global(variableName) {
     return {
-      global: {
+      globals: {
         [variableName]: getIn(globalObject, variableName),
       },
     };

--- a/packages/batteries/src/global/global.test.js
+++ b/packages/batteries/src/global/global.test.js
@@ -17,7 +17,7 @@ describe('globals', () => {
     const result = coeffectHandler(coeffectDescription.data);
 
     expect(result).toEqual({
-      global: {
+      globals: {
         [fakeVariable]: fakeValue,
       },
     });
@@ -36,7 +36,7 @@ describe('globals', () => {
     const result = coeffectHandler(coeffectDescription.data);
 
     expect(result).toEqual({
-      global: { [fakeVariablePath]: fakeValue },
+      globals: { [fakeVariablePath]: fakeValue },
     });
   });
 


### PR DESCRIPTION
### Summary

Global coeffect was exposing the result as `global` instead of `globals`. I noticed the error trying to run the example Todos app because the coeffect validation broke.

I didn't write a test for this. I guess that a way to check this is to make a test for every coeffect that the value it returns is inside an object with the name of the coeffect, but it feels a bit cumbersome... For the time, I just extracted a constant to ensure this. I guess I'll do the same with the rest of the batteries
