### PR TITLE
Added new http.delete effect handler

### DIFF
--- a/packages/batteries/src/http/http.js
+++ b/packages/batteries/src/http/http.js
@@ -59,6 +59,17 @@ export function httpPatch({ url, body, successEvent = [], errorEvent = [] }) {
   };
 }
 
+export function httpDelete({ url, body, successEvent = [], errorEvent = [] }) {
+  return {
+    'http.delete': {
+      url,
+      body,
+      successEvent: adaptEvent(successEvent),
+      errorEvent: adaptEvent(errorEvent),
+    }
+  };
+}
+
 export default function registerHttpEffect(
   httpClient,
   dispatch = reffectsDispatch
@@ -130,6 +141,24 @@ export default function registerHttpEffect(
     errorEvent = [],
   }) {
     httpClient.patch({
+      url,
+      body,
+      successFn(response) {
+        dispatchEvent(successEvent, response);
+      },
+      errorFn(error) {
+        dispatchEvent(errorEvent, error);
+      },
+    });
+  });
+
+  registerEffectHandler('http.delete', function patchEffect({
+    url,
+    body,
+    successEvent = [],
+    errorEvent = [],
+  }) {
+    httpClient.delete({
       url,
       body,
       successFn(response) {

--- a/packages/batteries/src/http/http.test.js
+++ b/packages/batteries/src/http/http.test.js
@@ -1,7 +1,7 @@
 import { clearHandlers, getEffectHandler } from 'reffects';
 import { destroyAllMocks } from '../../test-helpers/fixtures';
 import { callsTo } from '../../test-helpers/mockHelpers';
-import registerHttpEffect, { httpGet, httpPost, httpPut, httpPatch } from './http';
+import registerHttpEffect, {httpGet, httpPost, httpPut, httpPatch, httpDelete} from './http';
 
 describe('http effects', () => {
   afterEach(() => {
@@ -539,6 +539,120 @@ describe('http effects', () => {
 
       expect(httpPatchEffect).toEqual({
         'http.patch': {
+          url: 'https://github.com/trovit/reffects',
+          body: {hello: 'world'},
+          successEvent: ['callbackEvent', { arg1: 'arg1' }],
+          errorEvent: [],
+        }
+      });
+    });
+  });
+
+  describe('http.delete', () => {
+    const effectId = 'http.delete';
+
+    test('request success', () => {
+      const responseData = 'responseData';
+      const fakeHttpClient = {
+        delete: jest.fn().mockImplementation(function deleteFn({ successFn }) {
+          return successFn(responseData);
+        }),
+      };
+      const dispatchFake = jest.fn();
+      registerHttpEffect(fakeHttpClient, dispatchFake);
+      const httpEffectHandler = getEffectHandler(effectId);
+      const successEventId = 'successEventId';
+      const body = {
+        param: 'peanut',
+      };
+      const url = 'fakeUrl';
+
+      httpEffectHandler({
+        url,
+        body,
+        successEvent: [
+          successEventId,
+          eventRestOfPayload[0],
+          eventRestOfPayload[1],
+        ],
+      });
+
+      expect(fakeHttpClient.delete).toHaveBeenCalledWith({
+        url,
+        body,
+        successFn: expect.any(Function),
+        errorFn: expect.any(Function),
+      });
+      expect(dispatchFake).toHaveBeenCalledTimes(1);
+      expect(callsTo(dispatchFake)).toEqual([
+        [{ id: successEventId, payload: ['responseData', 'arg1', 'arg2'] }],
+      ]);
+    });
+
+    test('request error', () => {
+      const errorData = 'errorData';
+      const fakeHttpClient = {
+        delete: jest.fn().mockImplementation(function deleteFn({ errorFn }) {
+          return errorFn(errorData);
+        }),
+      };
+      const dispatchFake = jest.fn();
+      registerHttpEffect(fakeHttpClient, dispatchFake);
+      const httpEffectHandler = getEffectHandler(effectId);
+      const errorEventId = 'errorEventId';
+      const body = {
+        param: 'peanut',
+      };
+      const url = 'fakeUrl';
+
+      httpEffectHandler({
+        url,
+        body,
+        errorEvent: [
+          errorEventId,
+          eventRestOfPayload[0],
+          eventRestOfPayload[1],
+        ],
+      });
+
+      expect(fakeHttpClient.delete).toHaveBeenCalledWith({
+        url,
+        body,
+        successFn: expect.any(Function),
+        errorFn: expect.any(Function),
+      });
+      expect(dispatchFake).toHaveBeenCalledTimes(1);
+      expect(callsTo(dispatchFake)).toEqual([
+        [{ id: errorEventId, payload: ['errorData', 'arg1', 'arg2'] }],
+      ]);
+    });
+
+    test('should create an http.delete effect using a builder', () => {
+      const httpDeleteEffect = httpDelete({
+        url: 'https://github.com/trovit/reffects',
+        body: {hello: 'world'},
+        successEvent: ['callbackEvent', 'arg1']
+      });
+
+      expect(httpDeleteEffect).toEqual({
+        'http.delete': {
+          url: 'https://github.com/trovit/reffects',
+          body: {hello: 'world'},
+          successEvent: ['callbackEvent', 'arg1'],
+          errorEvent: [],
+        }
+      });
+    });
+
+    test('should create an http.delete effect using a builder with events as objects', () => {
+      const httpDeleteEffect = httpDelete({
+        url: 'https://github.com/trovit/reffects',
+        body: {hello: 'world'},
+        successEvent: { id: 'callbackEvent', payload: { arg1: 'arg1' } }
+      });
+
+      expect(httpDeleteEffect).toEqual({
+        'http.delete': {
           url: 'https://github.com/trovit/reffects',
           body: {hello: 'world'},
           successEvent: ['callbackEvent', { arg1: 'arg1' }],

--- a/packages/batteries/src/http/http.test.js
+++ b/packages/batteries/src/http/http.test.js
@@ -1,7 +1,7 @@
 import { clearHandlers, getEffectHandler } from 'reffects';
 import { destroyAllMocks } from '../../test-helpers/fixtures';
 import { callsTo } from '../../test-helpers/mockHelpers';
-import registerHttpEffect, {httpGet, httpPost, httpPut, httpPatch, httpDelete} from './http';
+import registerHttpEffect, { httpGet, httpPost, httpPut, httpPatch, httpDelete } from './http';
 
 describe('http effects', () => {
   afterEach(() => {

--- a/packages/batteries/src/http/index.test.js
+++ b/packages/batteries/src/http/index.test.js
@@ -17,7 +17,7 @@ describe('http battery', () => {
 
     registerQueryParamsBatteries(httpClient);
 
-    expect(registerEffectHandlerFn).toHaveBeenCalledTimes(4);
+    expect(registerEffectHandlerFn).toHaveBeenCalledTimes(5);
     expect(registerCoeffectHandlerFn).toHaveBeenCalledTimes(0);
     expect(registerBatteriesFn).toHaveBeenCalledWith(httpClient);
   });


### PR DESCRIPTION
### Summary

In our project we were required to make an HTTP DELETE request, but there is no effect that handles that in `httpBatteries`, so we extended that.