### PR TITLE
fix: Do nothing when there is an http error and there is no error event

### DIFF
--- a/packages/batteries/src/http/http.js
+++ b/packages/batteries/src/http/http.js
@@ -171,10 +171,14 @@ export default function registerHttpEffect(
   });
 
   function dispatchEvent(event, ...data) {
-    if (!event) {
+    if (eventIsUndefined(event)) {
       return;
     }
     const [id, ...rest] = event;
     dispatch({ id, payload: data.concat(rest) });
+  }
+
+  function eventIsUndefined(event) {
+    return !event || (Array.isArray(event) && event.length === 0)
   }
 }

--- a/packages/batteries/src/http/http.js
+++ b/packages/batteries/src/http/http.js
@@ -76,18 +76,14 @@ export default function registerHttpEffect(
 ) {
   registerEffectHandler('http.get', function getEffect({
     url,
-    successEvent = [],
+    successEvent,
     errorEvent = [],
     config = {},
   }) {
     httpClient.get({
       url,
-      successFn(response) {
-        dispatchEvent(successEvent, response);
-      },
-      errorFn(error) {
-        dispatchEvent(errorEvent, error);
-      },
+      successFn: dispatchMandatoryEvent('successEvent', successEvent),
+      errorFn: dispatchOptionalEvent(errorEvent),
       config
     });
   });
@@ -104,15 +100,9 @@ export default function registerHttpEffect(
       url,
       body,
       config,
-      successFn(response) {
-        dispatchEvent(successEvent, response);
-      },
-      errorFn(error) {
-        dispatchEvent(errorEvent, error);
-      },
-      alwaysFn() {
-        dispatchEvent(alwaysEvent);
-      },
+      successFn: dispatchOptionalEvent(successEvent),
+      errorFn: dispatchOptionalEvent(errorEvent),
+      alwaysFn: dispatchOptionalEvent(alwaysEvent),
     });
   });
 
@@ -125,12 +115,8 @@ export default function registerHttpEffect(
     httpClient.put({
       url,
       body,
-      successFn(response) {
-        dispatchEvent(successEvent, response);
-      },
-      errorFn(error) {
-        dispatchEvent(errorEvent, error);
-      },
+      successFn: dispatchOptionalEvent(successEvent),
+      errorFn: dispatchOptionalEvent(errorEvent),
     });
   });
 
@@ -143,12 +129,8 @@ export default function registerHttpEffect(
     httpClient.patch({
       url,
       body,
-      successFn(response) {
-        dispatchEvent(successEvent, response);
-      },
-      errorFn(error) {
-        dispatchEvent(errorEvent, error);
-      },
+      successFn: dispatchOptionalEvent(successEvent),
+      errorFn: dispatchOptionalEvent(errorEvent),
     });
   });
 
@@ -161,21 +143,32 @@ export default function registerHttpEffect(
     httpClient.delete({
       url,
       body,
-      successFn(response) {
-        dispatchEvent(successEvent, response);
-      },
-      errorFn(error) {
-        dispatchEvent(errorEvent, error);
-      },
+      successFn: dispatchOptionalEvent(successEvent),
+      errorFn: dispatchOptionalEvent(errorEvent),
     });
   });
 
-  function dispatchEvent(event, ...data) {
-    if (eventIsUndefined(event)) {
-      return;
-    }
+  function dispatchMandatoryEvent(name, event) {
+    return (...data) => {
+      if (eventIsUndefined(event)) {
+        throw new Error(`Missing ${name}`);
+      }
+      dispatchEvent(event, data);
+    };
+  }
+
+  function dispatchOptionalEvent(event) {
+    return (...data) => {
+      if (eventIsUndefined(event)) {
+        return;
+      }
+      dispatchEvent(event, data);
+    };
+  }
+
+  function dispatchEvent(event, data) {
     const [id, ...rest] = event;
-    dispatch({ id, payload: data.concat(rest) });
+    dispatch({id, payload: data.concat(rest)});
   }
 
   function eventIsUndefined(event) {

--- a/packages/batteries/src/http/http.test.js
+++ b/packages/batteries/src/http/http.test.js
@@ -85,6 +85,21 @@ describe('http effects', () => {
       ]);
     });
 
+    test('do nothing if request fails and errorEvent is not defined', () => {
+      const errorData = 'errorData';
+      const fakeHttpClient = {
+        get: jest.fn().mockImplementation(({errorFn}) => errorFn(errorData)),
+      };
+      const dispatchFake = jest.fn();
+      registerHttpEffect(fakeHttpClient, dispatchFake);
+      const httpEffectHandler = getEffectHandler(effectId);
+      const url = 'fakeUrl';
+
+      httpEffectHandler({ url });
+
+      expect(dispatchFake).not.toHaveBeenCalled();
+    });
+
     test('default config is empty object', () => {
       const errorData = 'errorData';
       const fakeHttpClient = {
@@ -277,6 +292,21 @@ describe('http effects', () => {
       ]);
     });
 
+    test('do nothing if request fails and errorEvent is not defined', () => {
+      const errorData = 'errorData';
+      const fakeHttpClient = {
+        post: jest.fn().mockImplementation(({errorFn}) => errorFn(errorData)),
+      };
+      const dispatchFake = jest.fn();
+      registerHttpEffect(fakeHttpClient, dispatchFake);
+      const httpEffectHandler = getEffectHandler(effectId);
+      const url = 'fakeUrl';
+
+      httpEffectHandler({ url });
+
+      expect(dispatchFake).not.toHaveBeenCalled();
+    });
+
     test('should create an http.post effect using a builder', () => {
       const httpPostEffect = httpPost({
         url: 'https://github.com/trovit/reffects',
@@ -399,6 +429,21 @@ describe('http effects', () => {
       ]);
     });
 
+    test('do nothing if request fails and errorEvent is not defined', () => {
+      const errorData = 'errorData';
+      const fakeHttpClient = {
+        put: jest.fn().mockImplementation(({errorFn}) => errorFn(errorData)),
+      };
+      const dispatchFake = jest.fn();
+      registerHttpEffect(fakeHttpClient, dispatchFake);
+      const httpEffectHandler = getEffectHandler(effectId);
+      const url = 'fakeUrl';
+
+      httpEffectHandler({ url });
+
+      expect(dispatchFake).not.toHaveBeenCalled();
+    });
+
     test('should create an http.put effect using a builder', () => {
       const httpPutEffect = httpPut({
         url: 'https://github.com/trovit/reffects',
@@ -513,6 +558,21 @@ describe('http effects', () => {
       ]);
     });
 
+    test('do nothing if request fails and errorEvent is not defined', () => {
+      const errorData = 'errorData';
+      const fakeHttpClient = {
+        patch: jest.fn().mockImplementation(({errorFn}) => errorFn(errorData)),
+      };
+      const dispatchFake = jest.fn();
+      registerHttpEffect(fakeHttpClient, dispatchFake);
+      const httpEffectHandler = getEffectHandler(effectId);
+      const url = 'fakeUrl';
+
+      httpEffectHandler({ url });
+
+      expect(dispatchFake).not.toHaveBeenCalled();
+    });
+
     test('should create an http.patch effect using a builder', () => {
       const httpPatchEffect = httpPatch({
         url: 'https://github.com/trovit/reffects',
@@ -625,6 +685,21 @@ describe('http effects', () => {
       expect(callsTo(dispatchFake)).toEqual([
         [{ id: errorEventId, payload: ['errorData', 'arg1', 'arg2'] }],
       ]);
+    });
+
+    test('do nothing if request fails and errorEvent is not defined', () => {
+      const errorData = 'errorData';
+      const fakeHttpClient = {
+        delete: jest.fn().mockImplementation(({errorFn}) => errorFn(errorData)),
+      };
+      const dispatchFake = jest.fn();
+      registerHttpEffect(fakeHttpClient, dispatchFake);
+      const httpEffectHandler = getEffectHandler(effectId);
+      const url = 'fakeUrl';
+
+      httpEffectHandler({ url });
+
+      expect(dispatchFake).not.toHaveBeenCalled();
     });
 
     test('should create an http.delete effect using a builder', () => {

--- a/packages/batteries/src/http/http.test.js
+++ b/packages/batteries/src/http/http.test.js
@@ -85,6 +85,21 @@ describe('http effects', () => {
       ]);
     });
 
+    test('fail when successEvent is not defined', () => {
+      const responseData = 'responseData';
+      const fakeHttpClient = {
+        get: jest.fn().mockImplementation(({successFn}) => successFn(responseData)),
+      };
+      const dispatchFake = jest.fn();
+      registerHttpEffect(fakeHttpClient, dispatchFake);
+      const httpEffectHandler = getEffectHandler(effectId);
+      const url = 'fakeUrl';
+
+      expect(() => {
+        httpEffectHandler({ url });
+      }).toThrowError('Missing successEvent');
+    });
+
     test('do nothing if request fails and errorEvent is not defined', () => {
       const errorData = 'errorData';
       const fakeHttpClient = {


### PR DESCRIPTION
### Summary

Right now in the http battery it is not possible to not define a callback event for the effects. @raulferras and me saw this error while doing a task where we wanted to make a post request without caring about the response.

I've modified the `dispatchEvent` function in the http battery to check that event is undefined or that the array is empty :)
