### PR TITLE
feat: Set missing query params to undefined

### DIFF
--- a/packages/batteries/src/queryParams/queryParams.js
+++ b/packages/batteries/src/queryParams/queryParams.js
@@ -19,7 +19,7 @@ export default function registerQueryParamsCoeffect(globalObject) {
           });
 
         if (queryParamValue.length === 0) {
-          return Object.assign({}, queryParamValues, { [queryParam]: null });
+          return queryParamValues;
         }
 
         if (queryParamValue.length === 1) {

--- a/packages/batteries/src/queryParams/queryParams.test.js
+++ b/packages/batteries/src/queryParams/queryParams.test.js
@@ -25,7 +25,6 @@ describe('queryParams', () => {
         peanuts: '3',
         chesnuts: 'dilìcíous',
         nuts: ['cashew', 'pistachios'],
-        hazelnuts: null,
       },
     });
   });


### PR DESCRIPTION
Using undefined instead of null allows you to specify a default value when destructuring the resulting object

**Linked issue:** https://github.com/trovit/reffects/issues/59
