### PR TITLE
feat: subscribe event to store

### DIFF
--- a/packages/reffects-store/docs/subscriptions_api.md
+++ b/packages/reffects-store/docs/subscriptions_api.md
@@ -1,5 +1,7 @@
 # Subscribing React components to changes in store's state
 
+## React components
+
 You need have to ways to subscribe a component to the state:
 
 1. [subscribe](#subscribe)
@@ -86,4 +88,51 @@ export default function Counter({
 function countSelector(state) {
   return state.count;
 }
+```
+
+## Events
+
+You can also dispatch events based on the state's changes.
+
+### `subscribeEvent`
+
+The `subscribeEvent` function subscribes an event id to given [reselect](https://github.com/reduxjs/reselect)'s selectors, so that events are only dispatched when the values in the application state tracked by the given selectors change.
+
+It gets as first parameter the event id we want to subscribe to the store.
+
+As second parameter, it receives a `mapStateToPayload` function which maps the application state to a payload that is compatible with the subscribed event id.
+
+Keep in mind that events will be dispatched only if the result of `mapStateToPayload` contains data that is not equivalent to data from previous mapped state.
+
+The `subscribeEvent` function returns a callable that, when invoked, unsubscribes the event id. Meaning that it will stop dispatching events when the state changes.
+
+Example:
+
+```js
+import { dispatch } from "packages/reffects/dist/reffects.es";
+import { subscribeEvent, state } from "packages/reffects-store/dist/reffects-store.es";
+
+// An event that checks if the player won
+registerEventHandler('CHECK_VICTORY', function checkVictory(_, counter) {
+  if (counter === 100) {
+    return state.set({'game.youWon': true});
+  } else {
+    return state.set({'game.youWon': undefined})
+  }
+});
+
+// Example of a simple selector
+function countSelector(state) {
+  return state.count;
+}
+
+export default subscribeEvent(
+  'CHECK_VICTORY',
+  function(state) {
+    return countSelector(state);
+  }
+);
+
+dispatch('INCREMENT_COUNTER');
+
 ```

--- a/packages/reffects-store/src/index.js
+++ b/packages/reffects-store/src/index.js
@@ -1,6 +1,7 @@
 import store from './store';
 import subscribe from './subscription';
 import useSelector from './subscription/useSelector';
+import subscribeEvent from './subscription/subscribeEvent';
 import registerStateBatteries, { state } from './batteries';
 
 const devToolsOn =
@@ -16,4 +17,11 @@ if (devToolsOn) {
   };
 }
 
-export { store, subscribe, useSelector, registerStateBatteries, state };
+export {
+  store,
+  subscribe,
+  useSelector,
+  subscribeEvent,
+  registerStateBatteries,
+  state,
+};

--- a/packages/reffects-store/src/subscription/subscribeEvent.js
+++ b/packages/reffects-store/src/subscription/subscribeEvent.js
@@ -1,0 +1,29 @@
+import { dispatch as defaultDispatch } from 'reffects';
+import isEqual from 'lodash.isequal';
+import * as storeModule from '../store';
+
+export default function subscribeEvent(
+  eventId,
+  mapStateToPayload,
+  store = storeModule,
+  dispatch = defaultDispatch
+) {
+  let currentSelection = mapStateToPayload(store.getState());
+
+  function update() {
+    const nextSelection = mapStateToPayload(store.getState());
+
+    if (isEqual(currentSelection, nextSelection)) {
+      return;
+    }
+
+    currentSelection = nextSelection;
+    dispatch({ id: eventId, payload: nextSelection });
+  }
+
+  store.subscribeListener(update);
+
+  return function unsubscribe() {
+    store.unsubscribeListener(update);
+  };
+}

--- a/packages/reffects-store/src/subscription/subscribeEvent.test.js
+++ b/packages/reffects-store/src/subscription/subscribeEvent.test.js
@@ -1,0 +1,148 @@
+import * as storeModule from '../store';
+import subscribeEvent from './subscribeEvent';
+
+function manageSubscriptions() {
+  let subscriptions = [];
+
+  return [
+    function givenSubscription(unsubscribe) {
+      subscriptions.push(unsubscribe);
+    },
+    function unsubscribeAll() {
+      subscriptions.forEach(unsubscribe => unsubscribe());
+      subscriptions = [];
+    },
+  ];
+}
+
+const withMapperThat = {
+  picksJustOnePropertyValue(propertyName) {
+    return state => state[propertyName];
+  },
+  returnsSubsetOfProperties(...propertyNames) {
+    return state => {
+      Object.fromEntries(
+        Object.entries(state).filter(([propertyName]) =>
+          propertyNames.includes(propertyName)
+        )
+      );
+    };
+  },
+};
+
+describe('subscribeEvent', () => {
+  const [givenSubscription, unsubscribeAll] = manageSubscriptions();
+  const dispatch = jest.fn();
+
+  afterEach(() => {
+    storeModule.initialize({});
+    unsubscribeAll();
+    dispatch.mockReset();
+  });
+
+  it('returns a function to stop unsubscribe event from store changes', () => {
+    const propertyName = 'speed';
+    const unsubscribe = subscribeEvent(
+      'myEvent',
+      withMapperThat.picksJustOnePropertyValue(propertyName),
+      storeModule,
+      dispatch
+    );
+    unsubscribe();
+
+    storeModule.setState({
+      path: propertyName,
+      newValue: 'human level',
+    });
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("applies mapStateToPayload to the store's state", () => {
+    const eventId = 'dies-on-mcu';
+    const mapStateToPayload = jest.fn();
+    givenSubscription(
+      subscribeEvent(eventId, mapStateToPayload, storeModule, dispatch)
+    );
+
+    storeModule.setState({
+      path: 'heroes.hulk.strength',
+      newValue: 'super level',
+    });
+
+    expect(mapStateToPayload).toBeCalledWith(storeModule.getState());
+  });
+
+  it('dispatches the event with a payload equal to the result of mapStateToPayload', () => {
+    const eventId = 'appears-on-earth-616';
+    const propertyName = 'fighting';
+    const propertyValue = 'over-human level';
+    givenSubscription(
+      subscribeEvent(
+        eventId,
+        withMapperThat.picksJustOnePropertyValue(propertyName),
+        storeModule,
+        dispatch
+      )
+    );
+
+    storeModule.setState({
+      path: propertyName,
+      newValue: propertyValue,
+    });
+
+    const expectedEvent = {
+      id: eventId,
+      payload: propertyValue,
+    };
+    expect(dispatch).toBeCalledWith(expectedEvent);
+  });
+
+  it('does not dispatch the event when mapStateToPayload returns the same data', () => {
+    const ignoredPropertyName = 'intelligence';
+    storeModule.initialize({
+      energy: 'over-human level',
+      speed: 'super level',
+      [ignoredPropertyName]: 'human level',
+    });
+    givenSubscription(
+      subscribeEvent(
+        'becomes-a-zombie-on-earth-2149',
+        withMapperThat.picksJustOnePropertyValue('energy', 'speed'),
+        storeModule,
+        dispatch
+      )
+    );
+
+    storeModule.setState({
+      path: ignoredPropertyName,
+      newValue: 'super level',
+    });
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('does not dispatch the event when mapStateToPayload returns a different object with same data inside', () => {
+    const ignoredPropertyName = 'strength';
+    storeModule.initialize({
+      durability: 'human level',
+      intelligence: 'over-human level',
+      [ignoredPropertyName]: 'super level',
+    });
+    givenSubscription(
+      subscribeEvent(
+        'has-descendants-on-earth-1610',
+        withMapperThat.returnsSubsetOfProperties('durability', 'intelligence'),
+        storeModule,
+        dispatch
+      )
+    );
+
+    storeModule.setState({
+      path: ignoredPropertyName,
+      newValue: 'over-human value',
+    });
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Subscribe event ids to state changes

This PR provides a way to dispatch events based on the state changes via a new function called `subscribeEvent()`.

This feature seems quite natural to me as it encourages the usage of events.
It also keeps access to certain low level functions like `subscribeListener()` or `unsubscribeListener()` away from programmers, which may be harmful to the idea behind reffects otherwise.

Furthermore, this feature can be really useful to deal with very hostile code, like code with persistence layers relying on abandoned libraries with amalgamated logic that needs to be untangled little by little.

The `subscribeEvent()` gets as first parameter the event id we want to subscribe to the store.

As second parameter, it receives a `mapStateToPayload` function which maps the application state to a payload that is compatible with the subscribed event id.

The `subscribeEvent` function returns a callable that, when invoked, unsubscribes the event id. Meaning that it will stop dispatching events when the state changes.

This is an example, included in the docs inside the PR, to illustrate how it is used:

```js
import { dispatch } from "packages/reffects/dist/reffects.es";
import { subscribeEvent, state } from "packages/reffects-store/dist/reffects-store.es";

// An event that checks if the player won
registerEventHandler('CHECK_VICTORY', function checkVictory(_, counter) {
  if (counter === 100) {
    return state.set({'game.youWon': true});
  } else {
    return state.set({'game.youWon': undefined})
  }
});

// Example of a simple selector
function countSelector(state) {
  return state.count;
}

export default subscribeEvent(
  'CHECK_VICTORY',
  function mapStateToPayload(state) {
    return countSelector(state);
  }
);

dispatch('INCREMENT_COUNTER');

```

One real application I am keeping in mind is the next one:

We maintain a project that uses Backbone.js models. We have some coeffects and effects to read and write from Backbone models and collections left unfinished. One of those effects is called `backbone.modelSet`.

Those effects and coeffects are great to start encapsulating logic inside event handlers. But with this feature, we could also work more easily on techniques like parallel change or adapters that transform state changes into `change` events on Backbone models to start abandoning the usage of Backbone itself.

For instance, we could start working with React components relying on the same data as old views, but directly stored in the state instead of getting them from events that use `backbone.modelGet` coeffects to read and `state.set` to store that data. That way we could restrict the usage of backbone effects and coeffects just for dealing with legacy views and the newer parts would make use of events not relying on anything tied to Backbone.

Another big advantage is to start replacing the usage of Backbone models and collections inside Backbone views.

```js

function registerBackboneModel(model) {
  const setEffectId = generateEventId( /*...*/ );

  registerEffectHandler(setEffectId, function setEffect(newAttributes) {
    model.set(newAttributes);
  });
  
  return {
    set(newAttributes) {
      return { [setEffectId]: newAttriButes };
    }
  };
}

const myModelReffects = registerBackboneModel(myModel);

registerEventHandler('SET_COUNTER_TO_MODEL', function (_, counter) {
  return myModelReffects.set({ 'counter': counter });
});

subscribeEvent('SET_COUNTER_TO_MODEL', function mapStateToPayload(state) {
  return state.counter;
});

function youWonSelector(state) {
  return state.counter === 100;
}

export default subscribe(VictoryComponent, function mapStateToProps(state) {
  // when counter reaches 100 inside the state, the component reacts 
  return {
    youWon: youWonSelector(state),
  }
});

const VictoryBackboneView = Backbone.View.extend({
  events: {
    'click #increase-counter-btn': 'increaseCounter',
  },

  initialize() {
    // when counter inside the state changes, the model is updated too and 'change:counter' is triggered
    this.model.on('change:counter', counterChanged),
  },
  counterChanged() {
    // when counter reaches 100 inside the backbone model in this case, an alert is shown
    if (this.get('counter') === 100) {
      alert('YOU WIN!');
    }
  },
  increaseCounter() {
    // Here we can safely dispatch and event to increase the counter inside the store instead of calling backbone's set().
    // The model will get updated anyway.
    dispatch('INCREASE_COUNTER');
    // this.model.set('counter', this.model.get('counter') + 1); 
  }
});

export const victoryView = new VictoryBackboneView({ model: myModel });

```
