### PR TITLE
fix: compare states in useSelector with deep equality

### DIFF
--- a/packages/reffects-store/src/subscription/index.js
+++ b/packages/reffects-store/src/subscription/index.js
@@ -15,16 +15,9 @@ function subscribe(
       let currentMappedProps = mapStateToProps(store.getState(), props);
 
       function update() {
-        let shouldForceUpdate = false;
         const nextMappedProps = mapStateToProps(store.getState(), props);
 
-        // Compares the current derived state props against the current state props
-        for (const i in nextMappedProps) {
-          if (isEqual(nextMappedProps[i], currentMappedProps[i]) === false) {
-            shouldForceUpdate = true;
-          }
-        }
-        if (shouldForceUpdate) {
+        if (!isEqual(nextMappedProps, currentMappedProps)) {
           currentMappedProps = nextMappedProps;
           forceUpdate();
         }

--- a/packages/reffects-store/src/subscription/useSelector.js
+++ b/packages/reffects-store/src/subscription/useSelector.js
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import * as store from '../store';
 import useForceUpdate from './utils';
+import isEqual from "lodash.isequal";
 
 export default function useSelector(selector) {
   const forceUpdate = useForceUpdate();
@@ -9,7 +10,7 @@ export default function useSelector(selector) {
   function update() {
     const nextSelectedState = selector(store.getState());
 
-    if (nextSelectedState === currentSelectedState) {
+    if (isEqual(nextSelectedState, currentSelectedState)) {
       return;
     }
 

--- a/packages/reffects-store/src/subscription/useSelector.test.js
+++ b/packages/reffects-store/src/subscription/useSelector.test.js
@@ -98,6 +98,28 @@ describe('useSelector hook', () => {
     expect(ComponentUsingSelector).toHaveCommittedTimes(1);
   });
 
+  it("shouldn't update the component using it when the state is the same with an array", () => {
+    const initialProps = { a: [1, 2] };
+    const store = storeModule;
+    store.initialize(initialProps);
+    const ComponentUsingSelector = withProfiler(() => {
+      const a = useSelector(state => state.a);
+      return <div>{JSON.stringify(a)}</div>;
+    });
+
+    const wrapper = mount(<ComponentUsingSelector />);
+    expect(extractTextFrom(wrapper, ComponentUsingSelector)).toBe('[1,2]');
+
+    act(() => {
+      store.setState({ path: ['a'], newValue: [1, 2] });
+      store.setState({ path: ['koko'], newValue: 'loko' });
+    });
+    wrapper.update();
+
+    expect(extractTextFrom(wrapper, ComponentUsingSelector)).toBe('[1,2]');
+    expect(ComponentUsingSelector).toHaveCommittedTimes(1);
+  });
+
   it('should render the component once despite of the times useSelector is called in a component', () => {
     const initialProps = { a: 1, b: 'koko', c: [1] };
     const store = storeModule;


### PR DESCRIPTION
### Summary

When using `subscribe` to subscribe a component to the state, it was using `isEqual` to deeply compare the previous and current state. In `useSelector` we were using `===`, which fails for non primitive types.

I've added a test with arrays, and it should work also for objects, but when running the whole suite of tests this test was failing (but worked when running only this one). I guess there's some shared state between the tests related to enzyme or some other test library, but since it seems to work, I'd like to merge this fix now and take a look later to improve the tests.

```
it("shouldn't update the component using it when the state is the same with an object", () => {
  const initialProps = { a: { b: 2 } };
  const store = storeModule;
  store.initialize(initialProps);
  const ComponentUsingSelector = withProfiler(function Foo() {
    const a = useSelector(state => state.a);
    return <div>{a.b}</div>;
  });

  const wrapper = mount(<ComponentUsingSelector />);
  expect(extractTextFrom(wrapper, ComponentUsingSelector)).toBe('2');

  act(() => {
    store.setState({ path: ['a'], newValue: { b: 2 } });
    store.setState({ path: ['koko'], newValue: 'loko' });
  });
  wrapper.update();

  expect(extractTextFrom(wrapper, ComponentUsingSelector)).toBe('2');
  expect(ComponentUsingSelector).toHaveCommittedTimes(1);
});
```
