### PR TITLE
feat: Add builder with empty effect

### DIFF
--- a/packages/reffects/src/index.js
+++ b/packages/reffects/src/index.js
@@ -186,6 +186,9 @@ const effects = {
         id, milliseconds, payload
       }
     };
+  },
+  none() {
+    return {};
   }
 };
 

--- a/packages/reffects/src/index.test.js
+++ b/packages/reffects/src/index.test.js
@@ -306,6 +306,10 @@ test('dispatchLater effect is created with a builder', () => {
   });
 });
 
+test('no effect created with a builder', () => {
+  expect(reffects.effects.none()).toStrictEqual({});
+});
+
 test('delegating events', () => {
   var callsCounter = 0;
   const expectedPayload = ['arg1', 'arg2'];


### PR DESCRIPTION
### Summary

I've added a function to create an empty effect `({})` in order to hide that the effects should be an object.
I think it is nice to hide that in case some day we wanted to change the effects to be an array, like in this PR https://github.com/trovit/reffects/issues/58
