### PR TITLE
feat: Make dispatch builder accept an object as an event

### DIFF
--- a/packages/reffects/src/index.js
+++ b/packages/reffects/src/index.js
@@ -168,10 +168,13 @@ registerEffectHandler('dispatchMany', dispatchMany);
 registerEffectHandler('dispatchLater', dispatchLater);
 
 const effects = {
-  dispatch(eventId, payload = {}) {
+  dispatch(event, payload = {}) {
+    if (event.id && event.payload) {
+      return { dispatch: event };
+    }
     return {
       dispatch: {
-        id: eventId, payload
+        id: event, payload
       }
     };
   },

--- a/packages/reffects/src/index.js
+++ b/packages/reffects/src/index.js
@@ -169,12 +169,10 @@ registerEffectHandler('dispatchLater', dispatchLater);
 
 const effects = {
   dispatch(event, payload = {}) {
-    if (event.id && event.payload) {
-      return { dispatch: event };
-    }
     return {
       dispatch: {
-        id: event, payload
+        id: event.id ?? event,
+        payload: event.payload ?? payload
       }
     };
   },

--- a/packages/reffects/src/index.test.js
+++ b/packages/reffects/src/index.test.js
@@ -206,6 +206,9 @@ test('dispatch effect is created with a builder', () => {
   expect(reffects.effects.dispatch({id: 'eventWithPayload', payload: {a: 1}})).toEqual({
     dispatch: { id: 'eventWithPayload', payload: {a: 1} }
   });
+  expect(reffects.effects.dispatch({id: 'event'})).toEqual({
+    dispatch: { id: 'event', payload: {} }
+  });
   expect(reffects.effects.dispatch('anotherEvent', { a: 1 })).toEqual({
     dispatch: { id: 'anotherEvent', payload: { a: 1} }
   });

--- a/packages/reffects/src/index.test.js
+++ b/packages/reffects/src/index.test.js
@@ -203,6 +203,9 @@ test('dispatch effect is created with a builder', () => {
   expect(reffects.effects.dispatch('someEvent')).toEqual({
     dispatch: { id: 'someEvent', payload: {} }
   });
+  expect(reffects.effects.dispatch({id: 'eventWithPayload', payload: {a: 1}})).toEqual({
+    dispatch: { id: 'eventWithPayload', payload: {a: 1} }
+  });
   expect(reffects.effects.dispatch('anotherEvent', { a: 1 })).toEqual({
     dispatch: { id: 'anotherEvent', payload: { a: 1} }
   });


### PR DESCRIPTION
### Summary

I think it was a mistake (mine 🙈) to make the dispatch builder accept two parameters, id and payload, instead of a string or an object. Why I think this? Because when you have an event that receives as a payload the event that it should dispatch you end up having to check if the event is a string or an object, in order to know how to call the builder. For example:

```js
registerEventHandler('foo', (_, {event}) => effects.dispatch(event.id ?? event, event.payload ?? {}))
```

But if you don't use the builder you could do

```js
registerEventHandler('foo', (_, {event}) => ({ dispatch: event }))
```

With this change, you could call

```js
registerEventHandler('foo', (_, {event}) => effects.dispatch(event))
```