### PR TITLE
Remove dependency with react-jest-profiler

### DIFF
--- a/packages/reffects-store/package-lock.json
+++ b/packages/reffects-store/package-lock.json
@@ -34,9 +34,9 @@
         "eslint-plugin-jest": "^22.4.1",
         "eslint-plugin-prettier": "^3.0.1",
         "jest": "^26.6.3",
-        "jest-react-profiler": "^0.1.3",
         "jest-when": "^3.4.1",
         "prettier": "^1.16.4",
+        "reffects": "^1.6.1-alpha.0",
         "rollup": "^2.33.2",
         "rollup-plugin-terser": "^5.3.1"
       },
@@ -6933,12 +6933,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jest-react-profiler": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/jest-react-profiler/-/jest-react-profiler-0.1.3.tgz",
-      "integrity": "sha512-rLMhEEna+Rbg7ksaOx6xVY1zcxzIj1foZz4UezjaaSqO5b0sn/Fyu/sA0DLAXAMvz+qwPVbTeyiXKZr99WBfDg==",
-      "dev": true
-    },
     "node_modules/jest-regex-util": {
       "version": "26.0.0",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
@@ -9178,7 +9172,7 @@
       "version": "1.6.1-alpha.0",
       "resolved": "https://registry.npmjs.org/reffects/-/reffects-1.6.1-alpha.0.tgz",
       "integrity": "sha512-wrCNE9k59endqxeOcxJI+Arb3zXG6lDX7ImaQ/jAFeSwzSWpM+sastav0oH8DHDfaF11wTZNQmFFy4i5/d5BGg==",
-      "peer": true
+      "dev": true
     },
     "node_modules/regenerate": {
       "version": "1.4.0",
@@ -17154,12 +17148,6 @@
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
       "dev": true
     },
-    "jest-react-profiler": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/jest-react-profiler/-/jest-react-profiler-0.1.3.tgz",
-      "integrity": "sha512-rLMhEEna+Rbg7ksaOx6xVY1zcxzIj1foZz4UezjaaSqO5b0sn/Fyu/sA0DLAXAMvz+qwPVbTeyiXKZr99WBfDg==",
-      "dev": true
-    },
     "jest-regex-util": {
       "version": "26.0.0",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
@@ -18873,7 +18861,7 @@
       "version": "1.6.1-alpha.0",
       "resolved": "https://registry.npmjs.org/reffects/-/reffects-1.6.1-alpha.0.tgz",
       "integrity": "sha512-wrCNE9k59endqxeOcxJI+Arb3zXG6lDX7ImaQ/jAFeSwzSWpM+sastav0oH8DHDfaF11wTZNQmFFy4i5/d5BGg==",
-      "peer": true
+      "dev": true
     },
     "regenerate": {
       "version": "1.4.0",

--- a/packages/reffects-store/package.json
+++ b/packages/reffects-store/package.json
@@ -36,7 +36,6 @@
     "eslint-plugin-jest": "^22.4.1",
     "eslint-plugin-prettier": "^3.0.1",
     "jest": "^26.6.3",
-    "jest-react-profiler": "^0.1.3",
     "jest-when": "^3.4.1",
     "prettier": "^1.16.4",
     "reffects": "^1.6.1-alpha.0",

--- a/packages/reffects-store/src/subscription/index.test.js
+++ b/packages/reffects-store/src/subscription/index.test.js
@@ -1,7 +1,7 @@
-import { withProfiler } from 'jest-react-profiler';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { render } from '@testing-library/react';
+import withProfiler from './rendererProfiler';
 import subscribe from '.';
 import * as storeModule from '../store';
 import '@testing-library/jest-dom';

--- a/packages/reffects-store/src/subscription/rendererProfiler.js
+++ b/packages/reffects-store/src/subscription/rendererProfiler.js
@@ -1,0 +1,23 @@
+import { createElement, Profiler } from 'react';
+
+export default function withProfiler(Component) {
+  const onRender = () => {
+    SnapshotProfiler.__numCommits++;
+  };
+  const SnapshotProfiler = props =>
+    createElement(
+      Profiler,
+      { id: 'withProfiler', onRender },
+      createElement(Component, props)
+    );
+  SnapshotProfiler.__numCommits = 0;
+  return SnapshotProfiler;
+}
+
+function toHaveCommittedTimes(SnapshotProfiler, expectedNumCommits) {
+  expect(SnapshotProfiler.__numCommits).toBe(expectedNumCommits);
+  SnapshotProfiler.__numCommits = 0;
+  return { pass: true };
+}
+
+expect.extend({ toHaveCommittedTimes });

--- a/packages/reffects-store/src/subscription/useSelector.test.js
+++ b/packages/reffects-store/src/subscription/useSelector.test.js
@@ -1,7 +1,7 @@
-import { withProfiler } from 'jest-react-profiler';
 import React from 'react';
 import { render } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
+import withProfiler from './rendererProfiler';
 import * as storeModule from '../store';
 import useSelector from './useSelector';
 import '@testing-library/jest-dom';
@@ -73,12 +73,12 @@ describe('useSelector hook', () => {
   });
 
   it.each([
-    ['primitive', 1, '1'],
-    ['array', [1, 2], '[1,2]'],
-    ['object', { b: 2 }, '{"b":2}'],
+    ['primitive', 1, 1, '1'],
+    ['array', [1, 2], [1, 2], '[1,2]'],
+    ['object', { b: 2 }, { b: 2 }, '{"b":2}'],
   ])(
     "shouldn't update the component using it when the state is the same using %s",
-    (_, value, expected) => {
+    (_, value, newValue, expected) => {
       const initialProps = { a: value };
       const store = storeModule;
       store.initialize(initialProps);
@@ -91,7 +91,7 @@ describe('useSelector hook', () => {
       expect(getByText(expected)).toBeInTheDocument();
 
       act(() => {
-        store.setState({ path: ['a'], newValue: value });
+        store.setState({ path: ['a'], newValue });
         store.setState({ path: ['koko'], newValue: 'loko' });
       });
 


### PR DESCRIPTION
### Summary

We are trying to update reffects to a newer react version and react-jest-profiler prevents us from doing so.
We have removed the dependency and added a custom helper to have the same feature we were using from it.